### PR TITLE
Fix plz buffer killing edge case

### DIFF
--- a/plz-media-type.el
+++ b/plz-media-type.el
@@ -707,7 +707,7 @@ not.
                                          (funcall then (plz-media-type-then
                                                         plz-media-type--current
                                                         plz-media-type--response)))))))
-                   (buffer (process-buffer result)))
+                   (buffer (if (processp result) (process-buffer result) result)))
             (cond ((bufferp result)
                    (plz-media-type--handle-sync-response result))
                   ((processp result)


### PR DESCRIPTION
In some cases, the current logic for killing the response buffer after the async request does not kill the correct buffer. I've personally experienced this and I strongly suspect the issue s-kostyaev/ellama#164 is also caused by this.

I have not yet been able to determine the root cause of the problem. What seems most likely is that plz can sometimes call `:finally` without having called `:then` or `:else`, or sometimes kills the response buffer itself before calling `:finally`. A cursory look at the plz code suggests neither of these should be possible, but I might be missing something.

In any case, the changes in this PR seem to completely fix the issue.