### PR TITLE
Remove Emacs snapshot build for now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,6 @@ jobs:
           - 29.2
           - 29.3
           - 29.4
-          - snapshot
     steps:
     - uses: purcell/setup-emacs@master
       with:


### PR DESCRIPTION
The snapshot Emacs build seems to remove `if-let` and `when-let`.